### PR TITLE
feat(suite): bind this to the current test

### DIFF
--- a/lib/dalek/suite.js
+++ b/lib/dalek/suite.js
@@ -237,15 +237,16 @@ Suite.prototype = {
 
   executeNextTest: function (tests) {
     // grab the next test in the queue
-    var testName = this.getNextTest(tests);
+    var testName = this.getNextTest(tests),
     // get the next test function
-    var testFunction = this.getTest(testName);
+    testFunction = this.getTest(testName),
+    // generate an instance of the test
+    test = this.getTestInstance(testName);
     // run a setup function before the test, if given
     if (this.options.beforeEach) {
       this.options.beforeEach();
     }
-    // generate an instance of the test & start it
-    var test = this.getTestInstance(testName);
+    // start it
     return testFunction.apply(test,[test]);
   },
 


### PR DESCRIPTION
Bind this to the current test at execution.
Semantic: "this is the current test".

No need to use a function argument for accessing DSL.

Example Code:

``` js
module.exports = {
    // Checks if the <title> of ´github.com´ has the expected value
    'Page title is correct': function () {
        'use strict';
        this.expect(1);

        this
            .open('http://github.com')
            .assert.title('GitHub')
            .done();
    }
};

```

Also set test via the arguments array to backward compatibility.

I've also tried to add a test for this, but there is not so much base-tests to extend ...
So I'm not so deep enough into dalek to create the initial test-suite.
