### PR TITLE
Let user know why loading a suite failed

### DIFF
--- a/lib/dalek/suite.js
+++ b/lib/dalek/suite.js
@@ -98,7 +98,7 @@ Suite.prototype = {
         return suite;
       }
     } catch (e) {
-      this.error = 'Failure loading suite "' + testfile + '". Skipping!';
+      this.error = '\n' + e.name + ': ' + e.message + '\nFailure loading suite "' + testfile + '". Skipping!';
       return suite;
     }
 


### PR DESCRIPTION
Currently DalekJS does not give any info _why_ loading a test suite failed. If the test suite JS has for example a syntax error that the user has not spotted, it might be difficult for the user to understand why the suite does not load.

This PR prints error name and message before the warning. I'm not that familiar with Dalek internals, so let me know if there is some better way of logging the error.

before:

```
>> Warning: Failure loading suite "x_spec.js". Skipping!
Fatal error: connect ECONNREFUSED
```

after: 

```
>> Warning:
SyntaxError: Duplicate data property in object literal not allowed in strict mode
Failure loading suite "x_spec.js". Skipping!
Fatal error: connect ECONNREFUSED
```

ping @asciidisco
