### PR TITLE
Allow passing a JS test object rather than a filename of tests

### DIFF
--- a/lib/dalek/suite.js
+++ b/lib/dalek/suite.js
@@ -88,6 +88,18 @@ Suite.prototype = {
 
   loadTestsuite: function (testfile) {
     var suite = {};
+
+    // if the tests were passed in *as* a list of tests, just use them
+    if (testfile && typeof testfile === 'object') {
+      var allAreTestFunctions = true;
+      for (var testname in testfile) {
+        if (typeof testfile[testname] !== 'function') { allAreTestFunctions = false; }
+      }
+      if (allAreTestFunctions) {
+        return testfile;
+      }
+    }
+
     // catch any errors, like falsy requires & stuff
     try {
 


### PR DESCRIPTION
When using dalek from JS rather than from the command line, it is useful to be able to pass an object of tests rather than the filename of a file which contains tests.

Example (which works with provided patch) and is the only file required (no extra file containing tests needed):

var Dalek = require("dalekjs");

var tests1 = [{
    'Page title is correct': function (test) {
      test
        .open('http://google.com')
        .assert.title().is('Google', 'It has title')
        .done();
    }
}];

var dalek = new Dalek({
    tests: tests1, browser: ["chrome"],
    driver: [], reporter: [], viewport: {}, logLevel: 5, 
    noColors: true, noSymbols: false, remote: null
});

dalek.run();
var Dalek = require("dalekjs");

var tests1 = [{
    'Page title is correct': function (test) {
      test
        .open('http://google.com')
        .assert.title().is('Google', 'It has title')
        .done();
    }
},{
    'Page title is correct, 2': function (test) {
      test
        .open('http://dalekjs.com')
        .assert.title().is(
            'DalekJS - Automated cross browser testing with JavaScript',
            'It has title')
        .done();
    }
}];

var dalek = new Dalek({
    tests: tests1, browser: ["chrome"],
    driver: [], reporter: [], viewport: {}, logLevel: 5,
    noColors: true, noSymbols: false, remote: null
});

dalek.run();
