### PR TITLE
have process exit code 1 if an assertion fails

### DIFF
--- a/lib/dalek.js
+++ b/lib/dalek.js
@@ -180,10 +180,10 @@ Dalek.prototype = {
       var processExitCaptured = false;
 
       process.on('exit', function() {
-        if(processExitCaptured == false) {
-            processExitCaptured = true;
-            process.exit(1);
-          }
+        if(processExitCaptured === false) {
+          processExitCaptured = true;
+          process.exit(1);
+        }
       });
     }
 


### PR DESCRIPTION
Right now if an assertion fails, dalek with still exit with a code of 0.  This can be problematic if you want to integrate running dalek in some sort of process.  Lets say I have a node command line utility that builds my library.  Part of that build process is to execute the dalek tests.  I would like to be able to run something like this:

`````` tool-builder```

This will then internal execute ```dalek``` and if any tests fail, I need to exit the build process before it actually builds the code.  Right now I would have to parse the output of the dalek process to determine if all the assertions passed and it is possible that output might change and if so, this tool would have to be updated.  It would be a lot easier if the tool code just say:

```javascript
if(dalekResult.code !== 0) {
  //error out code
}
``````

Now I could not find a place where dalek is explicitly exiting the process after all the test have executed so this is the best location I could find to put this code.  Dalek still runs fine (and close all child processes like browser windows) for passing and failing runs but if there is a better place for this, please let me know.
