### PR TITLE
Fixed wrong example for waitFor (2nd param has to be an array)

### DIFF
--- a/lib/dalek/actions.js
+++ b/lib/dalek/actions.js
@@ -876,7 +876,7 @@ Actions.prototype.execute = function (script) {
  *  test.open('http://adomain.com')
  *     .waitFor(function (aCheck) {
  *       return window.myThing === aCheck;
- *     }, 'aValue', 10000)
+ *     }, ['arg1', 'arg2'], 10000)
  *     .done();
  * ```
  *


### PR DESCRIPTION
Hi Sebastian,

as you just said in the IRC there's an error in the example of waitFor. Here's a fix for that.

Best
Marc
