### PR TITLE
Fix various typos

### DIFF
--- a/lib/dalek.js
+++ b/lib/dalek.js
@@ -129,11 +129,11 @@ Dalek.prototype = {
    */
 
   run: function () {
-    // early return; in case of remote 
+    // early return; in case of remote
     if (this.options.remote) {
       return this;
     }
-    
+
     // start the timer to measure the execution time
     this.timer.start();
 
@@ -147,7 +147,7 @@ Dalek.prototype = {
   },
 
   /**
-   * Reports the all testuites executed event
+   * Reports the all testsuites executed event
    *
    * @method testsuitesFinished
    * @chainable
@@ -160,7 +160,7 @@ Dalek.prototype = {
   },
 
   /**
-   * Reports the all testuites executed event
+   * Reports the all testsuites executed event
    *
    * @method reportRunFinished
    * @chainable
@@ -316,7 +316,7 @@ Dalek.prototype = {
   /**
    * Make sure to shutdown dalek & its spawned
    * components, webservers gracefully if a
-   * runtimew error pops up
+   * runtime error pops up
    *
    * @method _registerExceptionHandler
    * @private
@@ -342,7 +342,7 @@ Dalek.prototype = {
     if (exception.message && exception.message.search('This socket has been ended by the other party') !== -1) {
       return false;
     }
-    
+
     this.driverEmitter.emit('killAll');
     this.reporterEvents.emit('error', exception);
   }

--- a/lib/dalek/config.js
+++ b/lib/dalek/config.js
@@ -73,7 +73,7 @@ var Config = function (defaults, opts, advOpts) {
  * $ dalek mytest.js -d sauce
  * ```
  *
- * In order to run your tests within the Sauce Labs infrastructure, you must add your sauce username & key 
+ * In order to run your tests within the Sauce Labs infrastructure, you must add your sauce username & key
  * to your dalek configuration. Those two parameters must be set in order to get this driver up & running.
  * You can specifiy them within your [Dalekfile](/docs/config.html) like so:
  *
@@ -95,7 +95,7 @@ var Config = function (defaults, opts, advOpts) {
  * }
  * ```
  *
- * If you would like to have a more control over the browser/OS combinations that are available, you are able 
+ * If you would like to have a more control over the browser/OS combinations that are available, you are able
  * to configure you custom combinations:
  *
  * ```javascript
@@ -116,7 +116,7 @@ var Config = function (defaults, opts, advOpts) {
  *     "version": 26
  *   }
  * ```
- * 
+ *
  * You can then call your custom browsers like so:
  *
  * ```bash
@@ -165,7 +165,7 @@ Config.prototype = {
    * @method _checkFile
    * @param {String} previousValue Last iterations result
    * @param {String} ext File extension to check
-   * @param {integer} idx Iteration index 
+   * @param {integer} idx Iteration index
    * @param {object} data File data
    * @return {String} config File path
    * @private
@@ -229,7 +229,7 @@ Config.prototype = {
       delete opts.tests;
     }
 
-    if(data.tests && _.isArray(data.tests) && data.tests.length > 0) {
+    if (data.tests && _.isArray(data.tests) && data.tests.length > 0) {
       var tests = [];
 
       //get all the files that match
@@ -357,7 +357,7 @@ Config.prototype = {
    * Verifies if a driver is given, exists & is valid
    *
    * @method _verify
-   * @param {array} check Data that shoudl be mapped
+   * @param {array} check Data that should be mapped
    * @param {string} fn Name of the function that should be invoked on the veryify object
    * @param {object} instance Object instance where the verify function should be invoked
    * @return {array} data List of verified items

--- a/lib/dalek/driver.js
+++ b/lib/dalek/driver.js
@@ -228,7 +228,7 @@ Driver.prototype = {
         };
       }
     }
-    
+
     return browserConfiguration;
   },
 
@@ -278,7 +278,7 @@ Driver.prototype = {
    * browser running event & starts a new async() sesries execution
    * Will be called when the driver is ready
    *
-   * @method _onDriverReadyclear
+   * @method _onDriverReady
    * @param {string} browser Name of the requested browser
    * @param {string} driverName Name of the requested driver
    * @param {function} callback Asyncs next() callback function
@@ -296,10 +296,10 @@ Driver.prototype = {
   },
 
   /**
-   * Emits a 'tests complete' event & calls asyncs next() callback
+   * Emits a 'tests complete' event & calls async's next() callback
    *
    * @method _onTestsuiteComplete
-   * @param {function} callback Asyncs next() callback function
+   * @param {function} callback Async's next() callback function
    * @param {string} driverName Name of the requested driver
    * @param {string} browser Name of the requested browser
    * @chainable
@@ -344,7 +344,7 @@ Driver.prototype = {
       browserConfiguration.module.setBrowser(browser);
     }
 
-    // init the driver instance 
+    // init the driver instance
     var driverInstance = driverModule.create({events: this.driverEmitter, reporter: this.reporterEvents, browser: browser, config: this.config, browserMo: browserConfiguration.module, browserConf: browserConfiguration.configuration});
     // couple driver & session status events for the reporter
     this.coupleReporterEvents(driverName, browser);

--- a/lib/dalek/suite.js
+++ b/lib/dalek/suite.js
@@ -150,7 +150,7 @@ Suite.prototype = {
       this.options.teardown();
     }
 
-    // emit the suite started event
+    // emit the suite finished event
     this.reporterEmitter.emit('report:testsuite:finished', this.name);
 
     // move on to the next suite

--- a/lib/dalek/timer.js
+++ b/lib/dalek/timer.js
@@ -84,7 +84,7 @@ Timer.prototype = {
   },
 
   /**
-   * Returns an object with test run time informations
+   * Returns an object with test run time information
    * containing hours, minutes & seconds
    *
    * @method getElapsedTimeFormatted


### PR DESCRIPTION
There's also a typo in https://github.com/search?q=runnedExpactations%3A&type=Code but I was reluctant to fix it because it seems like it's part of the public api now?

Also, the contributing doc mentions a "wip" branch that should be used but none exists.
