### PR TITLE
initial attempt to add right click action

### DIFF
--- a/lib/dalek/actions.js
+++ b/lib/dalek/actions.js
@@ -163,7 +163,7 @@ Actions.prototype.mouseEvent = function (type, selector) {
  * For more information about this, I recommend to check out the [configuration docs](/docs/config.html)
  *
  * TODO: IMPLEMENT
- * 
+ *
  * @method setHttpAuth
  * @param {string} username
  * @param {string} password
@@ -203,7 +203,7 @@ Actions.prototype.setHttpAuth = function (username, password) {
  * ```
  *
  * > NOTE: Buggy in Firefox
- * 
+ *
  * @api
  * @method toFrame
  * @param {string} selector Selector of the frame to switch to
@@ -243,7 +243,7 @@ Actions.prototype.toFrame = function (selector) {
  * ```
  *
  * > NOTE: Buggy in Firefox
- * 
+ *
  * @api
  * @method toParent
  * @chainable
@@ -282,7 +282,7 @@ Actions.prototype.toParent = function () {
  * ```
  *
  * > NOTE: Buggy in Firefox
- * 
+ *
  * @api
  * @method toWindow
  * @param {string} name Name of the window to switch to
@@ -317,7 +317,7 @@ Actions.prototype.toWindow = function (name) {
  * ```
  *
  * > NOTE: Buggy in Firefox
- * 
+ *
  * @api
  * @method toParentWindow
  * @chainable
@@ -334,7 +334,7 @@ Actions.prototype.toParentWindow = function () {
  * Wait until a resource that matches the given testFx is loaded to process a next step.
  *
  * TODO: IMPLEMENT
- * 
+ *
  * @method waitForResource
  * @param {string} ressource URL of the ressource that should be waited for
  * @param {number} timeout Timeout in miliseconds
@@ -352,7 +352,7 @@ Actions.prototype.waitForResource = function (ressource, timeout) {
  * Waits until the passed text is present in the page contents before processing the immediate next step.
  *
  * TODO: IMPLEMENT
- * 
+ *
  * @method waitForText
  * @param {string} text Text to be waited for
  * @param {number} timeout Timeout in miliseconds
@@ -370,7 +370,7 @@ Actions.prototype.waitForText = function (text, timeout) {
  * Waits until an element matching the provided selector expression is visible in the remote DOM to process a next step.
  *
  * TODO: IMPLEMENT
- * 
+ *
  * @method waitUntilVisible
  * @param {string} selector Selector of the element that should be waited to become invisible
  * @param {number} timeout Timeout in miliseconds
@@ -394,7 +394,7 @@ Actions.prototype.waitUntilVisible = function (selector, timeout) {
  * Waits until an element matching the provided selector expression is no longer visible in remote DOM to process a next step.
  *
  * TODO: IMPLEMENT
- * 
+ *
  * @method waitWhileVisible
  * @param {string} selector Selector of the element that should be waited to become visible
  * @param {number} timeout Timeout in miliseconds
@@ -609,7 +609,7 @@ Actions.prototype.back = function () {
  * In the future it might become the ability to also execute a "right button" click.
  *
  * > Note: Does not work correctly in Firefox when used on `<select>` & `<option>` elements
- * 
+ *
  * @api
  * @method click
  * @param {string} selector Selector of the element to be clicked
@@ -625,6 +625,32 @@ Actions.prototype.click = function (selector) {
 
   var cb = this._generateCallbackAssertion('click', 'click', selector, hash);
   this._addToActionQueue([selector, hash], 'click', cb);
+  return this;
+};
+
+/**
+ * Performs a right click on the element matching the provided selector expression.
+ *
+ * @api
+ * @method rightClick
+ * @param {string} selector Selector of the element to be clicked
+ * @chainable
+ */
+
+Actions.prototype.rightClick = function (selector) {
+  var hash = uuid();
+
+  if (this.querying === true) {
+    selector = this.selector;
+  }
+
+  // 2 => right mouse button
+  // var rightButton = {'button': '2'};
+  // var rightButton = 'right';
+  var rightButton = '2';
+
+  var cb = this._generateCallbackAssertion('click', 'rightClick', selector, rightButton, hash);
+  this._addToActionQueue([selector, rightButton, hash], 'click', cb);
   return this;
 };
 
@@ -646,7 +672,7 @@ Actions.prototype.click = function (selector) {
  * ```
  *
  * > Note: Does not work in Firefox yet
- * 
+ *
  * @api
  * @method submit
  * @param {string} selector Selector of the form to be submitted
@@ -727,7 +753,7 @@ Actions.prototype.open = function (location) {
  * You can go [here](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value) to read up on special keys and unicodes for them (note that a code of U+EXXX is actually written in code as \uEXXX).
  *
  * > Note: Does not work correctly in Firefox with special keys
- * 
+ *
  * @api
  * @method type
  * @param {string} selector Selector of the form field to be filled
@@ -762,7 +788,7 @@ Actions.prototype.type = function (selector, keystrokes) {
  *
  *
  * > Note: Does not work correctly in Firefox with special keys
- * 
+ *
  * @api
  * @method sendKeys
  * @param {string} selector Selector of the form field to be filled
@@ -803,7 +829,7 @@ Actions.prototype.sendKeys = function (selector, keystrokes) {
  *
  *
  * > Note: Does not work in Firefox & PhantomJS
- * 
+ *
  * @api
  * @method answer
  * @param {string} keystrokes Text to be applied to the element
@@ -819,7 +845,7 @@ Actions.prototype.answer = function (keystrokes) {
 
 /**
  * Executes a JavaScript function within the browser context
- * 
+ *
  * ```javascript
  *  test.open('http://adomain.com')
  *     .execute(function () {
@@ -841,7 +867,7 @@ Actions.prototype.answer = function (keystrokes) {
  * ```
  *
  * > Note: Buggy in Firefox
- * 
+ *
  * @api
  * @method execute
  * @param {function} script JavaScript function that should be executed
@@ -881,7 +907,7 @@ Actions.prototype.execute = function (script) {
  * ```
  *
  * > Note: Buggy in Firefox
- * 
+ *
  * @method waitFor
  * @param {function} fn Async function that resolves an promise when ready
  * @param {array} args Additional arguments
@@ -919,7 +945,7 @@ Actions.prototype.waitFor = function (script, args, timeout) {
  * ```
  *
  * > Note: Does not work in Firefox & PhantomJS
- * 
+ *
  * @api
  * @method accept
  * @return chainable
@@ -953,7 +979,7 @@ Actions.prototype.accept = function () {
  * ```
  *
  * > Note: Does not work in Firefox & PhantomJS
- * 
+ *
  * @api
  * @method dismiss
  * @return chainable
@@ -998,7 +1024,7 @@ Actions.prototype.dismiss = function () {
  *
  *
  * > Note: Does not work in Firefox
- * 
+ *
  * @api
  * @method resize
  * @param {object} dimensions Width and height as properties to apply
@@ -1043,7 +1069,7 @@ Actions.prototype.resize = function (dimensions) {
  * ```
  *
  * > Note: Does not work in Firefox and PhantomJS
- * 
+ *
  * @api
  * @method maximize
  * @chainable
@@ -1180,7 +1206,7 @@ Actions.prototype.logger = {};
  *  DOM: #smth <input type="hidden" value="not really a value" id="ijustwannahaveavalue"/>
  * ```
 
- * 
+ *
  * @api
  * @method log.dom
  * @param {string} selector CSS selector
@@ -1226,7 +1252,7 @@ Actions.prototype.logger.dom = function (selector) {
  *     .log.message('FooBar') // outputs MESSAGE: FooBar
  *     .done();
  * ```
- * 
+ *
  * @api
  * @method log.message
  * @param {function|string} message
@@ -1336,13 +1362,13 @@ Actions.prototype._addToActionQueue = function (opts, driverMethod, cb) {
 
 Actions.prototype._button = function(button) {
   var buttons = {LEFT: 0, MIDDLE: 1, RIGHT: 2};
-  
+
   if (button === undefined) {
     button = 0;
   } else if (typeof button !== 'number') {
     button = buttons[button.toUpperCase()] || 0;
   }
-  
+
   return button;
 };
 
@@ -1350,29 +1376,29 @@ Actions.prototype._button = function(button) {
 Actions.prototype.buttonClick = function (button) {
   var hash = uuid();
   button = this._button(button);
-  
+
   var cb = this._generateCallbackAssertion('buttonClick', 'buttonClick');
   this._addToActionQueue([button, hash], 'buttonClick', cb);
-  
+
   return this;
 };
 
 // http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/moveto
 Actions.prototype.moveTo = function (selector, x, y) {
   var hash = uuid();
-  
+
   if (this.querying === true) {
     selector = this.selector;
   }
-  
+
   if (x === undefined) {
     x = null;
   }
-  
+
   if (y === undefined) {
     y = null;
   }
-  
+
   // move to coordinate
   var cb = this._generateCallbackAssertion('moveto', 'moveto');
   this._addToActionQueue([selector, x, y, hash], 'moveto', cb);


### PR DESCRIPTION
I am trying to add a right click action to DalekJS. Current commit doesn't perform a right click action.

I am trying to send a `{button = 2}` parameter to a WebDriver API [according to the W3C documentation](https://dvcs.w3.org/hg/webdriver/raw-file/default/webdriver-spec.html#methods-15)

I tried the following options with no result:

``` javascript
var rightButton = {'button': '2'};
var rightButton = 'right';
var rightButton = '2';
```

I am guessing that [this line](https://github.com/dalekjs/dalek/blob/master/lib/dalek/actions.js#L1324) doesn't call WebDriver API directly, does it? What shall I do in order to pass `{button = 2}` parameter further to the WebDriver API?

> P.S.
> traling spaces are removed as specified in the `.editorconfig` file.
