### PR TITLE
change doc for setValue

### DIFF
--- a/lib/dalek/actions.js
+++ b/lib/dalek/actions.js
@@ -1123,13 +1123,13 @@ Actions.prototype.waitForElement = function (selector, timeout) {
  * Fills the fields of a form with given values.
  *
  * ```html
- * <input type="hidden" value="not really a value" id="ijustwannahaveavalue"/>
+ * <input type="text" value="not really a value" id="ijustwannahaveavalue"/>
  * ```
  *
  * ```javascript
  * test.open('http://dalekjs.com')
  *     .setValue('#ijustwannahaveavalue', 'a value')
- *     .title().is('DalekJS - Frequently asked questions', 'What the F.A.Q.');
+ *     .assert.val('#ijustwannahaveavalue', 'a value', 'Value is changed');
  * ```
  *
  * @api


### PR DESCRIPTION
I changed the doc for setValue, because it is not possible with to change the value of an hidden element with setValue (webdriver is meant to act like a user and can't change hidden fields)
