### PR TITLE
Adding hasClass/dosntHaveClass asserion

### DIFF
--- a/lib/dalek/assertions.js
+++ b/lib/dalek/assertions.js
@@ -1420,7 +1420,7 @@ Assertions.prototype.hasClass = function (selector, expected, message) {
  * ```javascript
  *  test
  *    .open('http://dalekjs.com/guineapig/')
- *    .assert.doesntHaveClass('button.submit-product', 'btn', 'button doesn't have btn class')
+ *    .assert.doesntHaveClass('button.submit-product', 'btn', 'button doesn\'t have btn class')
  *    .done();
  * ```
  *


### PR DESCRIPTION
This PR is related to following issue https://github.com/dalekjs/dalek/issues/128
In PR was added two method that allow to test if element contains/don't contains class

``` javascript
test
    .open('http://dalekjs.com/guineapig/')
    .assert.hasClass('button.submit-product', 'plain-btn', 'button has plain-btn class')
    .done();
```

``` javascript
 test
   .open('http://dalekjs.com/guineapig/')
   .assert.doesntHaveClass('button.submit-product', 'btn', 'button doesn\'t have btn class')
   .done();
```
