### PR TITLE
 Fix:create custom assertions via callback

### DIFF
--- a/lib/dalek/assertions.js
+++ b/lib/dalek/assertions.js
@@ -1369,84 +1369,30 @@ Assertions.prototype.attr = function (selector, attribute, expected, message) {
 
 
 /**
- * Asserts that an elements contain class.
- *
- * ```html
- * <form>
- *   <button class="plain-btn action submit-product" type="submit">Fire</button>
- * </form>
- * ```
- *
- * ```javascript
- *  test
- *    .open('http://dalekjs.com/guineapig/')
- *    .assert.hasClass('button.submit-product', 'plain-btn', 'button has plain-btn class')
- *    .done();
- * ```
- *
- * @api
- * @method attr
- * @param {string} selector Selector that matches the elements to test
- * @param {string} expected Expected test result
- * @param {string} message Message for the test reporter
- * @chainable
- */
+Assert result of the execution of JavaScript function within the browser context.
+  
+  test
+    .open('http://dalekjs.com/index.html')
+    .assert.evaluate(function () {
+      return document.getElementsByClassName('grid').length;
+    }).is(2, 'Count of grid on page is equal 2');
 
-Assertions.prototype.hasClass = function (selector, expected, message) {
+* > Note: Buggy in Firefox
+*
+* @api
+* @method execute
+* @param {function} script JavaScript function that should be executed
+* @return chainable
+*/
+
+Assertions.prototype.evaluate = function (script) {
   var hash = uuid();
-  var attribute = 'class';
+  var args = [this.contextVars].concat(Array.prototype.slice.call(arguments, 1) || []);
 
-  if (this.test.querying === true) {
-    message = expected;
-    expected = selector;
-    selector = this.test.selector;
-  }
-
-  var cb = this._generateCallbackAssertion('attribute', 'hasClass', this._containsItem, hash, {expected: expected, message: message, selector: selector, attribute: attribute}).bind(this.test);
-  this._addToActionQueue([selector, attribute, expected, hash], 'attribute', cb);
+  var cb = this._generateCallbackAssertion('evaluate', 'evaluate', this._testTruthy, hash, {script: script, args: args, has:hash}).bind(this.test);
+  this._addToActionQueue([script, args, hash], 'evaluate', cb);
   return this.chaining ? this : this.test;
 };
-
-
-/**
- * Asserts that an elements don't contain class.
- *
- * ```html
- * <form>
- *   <button class="plain-btn action submit-product" type="submit">Fire</button>
- * </form>
- * ```
- *
- * ```javascript
- *  test
- *    .open('http://dalekjs.com/guineapig/')
- *    .assert.doesntHaveClass('button.submit-product', 'btn', 'button doesn\'t have btn class')
- *    .done();
- * ```
- *
- * @api
- * @method attr
- * @param {string} selector Selector that matches the elements to test
- * @param {string} expected Expected test result
- * @param {string} message Message for the test reporter
- * @chainable
- */
-
-Assertions.prototype.doesntHaveClass = function (selector, expected, message) {
-  var hash = uuid();
-  var attribute = 'class';
-
-  if (this.test.querying === true) {
-    message = expected;
-    expected = selector;
-    selector = this.test.selector;
-  }
-
-  var cb = this._generateCallbackAssertion('attribute', '!hasClass', this._doesntContainItem, hash, {expected: expected, message: message, selector: selector, attribute: attribute}).bind(this.test);
-  this._addToActionQueue([selector, attribute, expected, hash], 'attribute', cb);
-  return this.chaining ? this : this.test;
-};
-
 
 
 // TEST HELPER
@@ -1855,50 +1801,6 @@ Assertions.prototype._caseInsensitiveMatch = function (a, b) {
     } else {
       return false;
     }
-  } catch (e) {
-    return false;
-  }
-
-  return true;
-};
-
-/**
- * Assert if a given value contians a second given value
- *
- * @method _containsItem
- * @param {mixed} a Value to test
- * @param {mixed} b Value to test
- * @return {bool} false if values doesn't contain, true if contains
- * @private
- */
-
-Assertions.prototype._containsItem = function (a, b) {
-  a = a || '';
-  var index = a.split(' ').indexOf(b);
-
-  try {
-    chai.expect(index).to.be.above(-1);
-  } catch (e) {
-    return false;
-  }
-
-  return true;
-};
-
-/**
- * Assert if a given value doesn't contian a second given value
- *
- * @method _containsItem
- * @param {mixed} a Value to test
- * @param {mixed} b Value to test
- * @return {bool} false if values contains, true if don't contain
- * @private
- */
-Assertions.prototype._doesntContainItem = function (a, b) {
-  a = a || '';
-  var index = a.split(' ').indexOf(b);
-  try {
-    chai.assert.equal(index, -1);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Implemention of the following feature https://github.com/dalekjs/dalek/issues/123 - Custom assertions via callback

Examples of using 

``` javascript
test
    .open('http://dalekjs.com/index.html')
    .assert.evaluate(function () {
      return document.getElementsByClassName('grid').length;
    }).is(2, 'Count of grid on page is equal 2');
```
