### PR TITLE
send `data.selector` to 'report:assertion' so it could log the selector aswell

### DIFF
--- a/lib/dalek/assertions.js
+++ b/lib/dalek/assertions.js
@@ -1618,7 +1618,8 @@ Assertions.prototype._generateCallbackAssertion = function (key, type, test, has
         expected: opts.comparisonOperator ? opts.comparisonOperator + opts.expected : opts.expected,
         value: data.value,
         message: opts.message,
-        type: type
+        type: type,
+        selector: data.selector
       });
 
       this.incrementExpectations();


### PR DESCRIPTION
(e.g. 'VISIBLE #my-selector' instead of just 'VISIBLE').
this commit will be complimanted with a commit to dalek-reporter-console
repository to use the selector when logging (i'll pull request it right away)