### PR TITLE
docs: Fix simple typo, miliseconds -> milliseconds

### DIFF
--- a/lib/dalek/actions.js
+++ b/lib/dalek/actions.js
@@ -337,7 +337,7 @@ Actions.prototype.toParentWindow = function () {
  *
  * @method waitForResource
  * @param {string} ressource URL of the ressource that should be waited for
- * @param {number} timeout Timeout in miliseconds
+ * @param {number} timeout Timeout in milliseconds
  * @chainable
  */
 
@@ -355,7 +355,7 @@ Actions.prototype.waitForResource = function (ressource, timeout) {
  *
  * @method waitForText
  * @param {string} text Text to be waited for
- * @param {number} timeout Timeout in miliseconds
+ * @param {number} timeout Timeout in milliseconds
  * @chainable
  */
 
@@ -373,7 +373,7 @@ Actions.prototype.waitForText = function (text, timeout) {
  *
  * @method waitUntilVisible
  * @param {string} selector Selector of the element that should be waited to become invisible
- * @param {number} timeout Timeout in miliseconds
+ * @param {number} timeout Timeout in milliseconds
  * @chainable
  */
 
@@ -397,7 +397,7 @@ Actions.prototype.waitUntilVisible = function (selector, timeout) {
  *
  * @method waitWhileVisible
  * @param {string} selector Selector of the element that should be waited to become visible
- * @param {number} timeout Timeout in miliseconds
+ * @param {number} timeout Timeout in milliseconds
  * @chainable
  */
 
@@ -943,7 +943,7 @@ Actions.prototype.execute = function (script) {
  * @method waitFor
  * @param {function} fn Async function that resolves an promise when ready
  * @param {array} args Additional arguments
- * @param {number} timeout Timeout in miliseconds
+ * @param {number} timeout Timeout in milliseconds
  * @chainable
  * @api
  */


### PR DESCRIPTION
There is a small typo in lib/dalek/actions.js.

Should read `milliseconds` rather than `miliseconds`.

